### PR TITLE
preparePagSeguro js function declaration fix

### DIFF
--- a/view/frontend/templates/preparePagSeguro.phtml
+++ b/view/frontend/templates/preparePagSeguro.phtml
@@ -12,7 +12,7 @@ $ccPlaceholderImage = $this->getViewFileUrl('RicardoMartins_PagSeguro::images/cc
 <script src="<?php echo $viewJsPath;?>"></script>
 <script type="text/javascript">
      //<![CDATA[
-    var preparePagSeguro = function(){
+    function preparePagSeguro(){
         
         if(typeof RMPagSeguroObj != "undefined"){
             <?php if ($helper->isDebugActive()): ?>


### PR DESCRIPTION
preparePagSeguro js function declaration causing 

Uncaught ReferenceError: Unable to process binding "afterRender: function(){return preparePagSeguro() }"
Message: preparePagSeguro is not defined
    at afterRender (eval at createBindingsStringEvaluator (knockout.js:2982), <anonymous>:3:64)