### PR TITLE
Correção de exceção gerada na limpeza de cache de catálogos vazios

### DIFF
--- a/Model/Cache/Type/Interests.php
+++ b/Model/Cache/Type/Interests.php
@@ -45,42 +45,28 @@ class Interests extends TagScope
         );
         $this->eavConfig = $eavConfig;
     }
+
+    /**
+     * 
+     */
     public function clean($mode = \Zend_Cache::CLEANING_MODE_ALL, array $tags = [])
     {
-        if (!$this->productAttributeExists('rm_interest_options')
-            || !$this->productAttributeExists('rm_pagseguro_last_update')) {
+        // checks if interest attributes exist
+        if (!$this->productAttributeExists('rm_interest_options') ||
+            !$this->productAttributeExists('rm_pagseguro_last_update'))
+        {
             return;
         }
-        $objectManager = \Magento\Framework\App\ObjectManager::getInstance();
-        /** @var \Magento\Catalog\Model\ResourceModel\Product\Collection $productCollection */
-        $productCollection = $objectManager->create('Magento\Catalog\Model\ResourceModel\Product\Collection');
-        /** Apply filters here */
-        $collection = $productCollection->addAttributeToSelect('*')
-            ->load();
-        $productIds = [];
-        foreach($collection as $product){
-            $productIds[] = $product->getId();
-        }
-        $productActionObject = $objectManager->create('Magento\Catalog\Model\Product\Action');
-        $productActionObject->updateAttributes($productIds, array('rm_interest_options' => ""), 0);
-        $productActionObject->updateAttributes($productIds,array('rm_pagseguro_last_update' => 0), 0);
+
+        $this->_resetInterestProductAttributes();
     }
 
+    /**
+     * 
+     */
     public function flush($mode = \Zend_Cache::CLEANING_MODE_ALL, array $tags = [])
     {
-        $objectManager = \Magento\Framework\App\ObjectManager::getInstance();
-        /** @var \Magento\Catalog\Model\ResourceModel\Product\Collection $productCollection */
-        $productCollection = $objectManager->create('Magento\Catalog\Model\ResourceModel\Product\Collection');
-        /** Apply filters here */
-        $collection = $productCollection->addAttributeToSelect('*')
-            ->load();
-        $productIds = [];
-        foreach($collection as $product){
-            $productIds[] = $product->getId();
-        }
-        $productActionObject = $objectManager->create('Magento\Catalog\Model\Product\Action');
-        $productActionObject->updateAttributes($productIds, array('rm_interest_options' => ""), 0);
-        $productActionObject->updateAttributes($productIds,array('rm_pagseguro_last_update' => 0),0);
+        $this->_resetInterestProductAttributes();
     }
 
     /**
@@ -97,4 +83,31 @@ class Interests extends TagScope
         return ($attr && $attr->getId());
     }
 
+    /**
+     * Reset interest product 
+     * attributes values
+     */
+    private function _resetInterestProductAttributes()
+    {
+        $objectManager = \Magento\Framework\App\ObjectManager::getInstance();
+        
+        /** @var \Magento\Catalog\Model\ResourceModel\Product\Collection $productCollection */
+        $productCollection = $objectManager->create('Magento\Catalog\Model\ResourceModel\Product\Collection');
+
+        // only update attributes if 
+        // there are products on catalog
+        if($productCollection->getSize() > 0)
+        {
+            $productIds = [];
+            
+            foreach($productCollection as $product)
+            {
+                $productIds[] = $product->getId();
+            }
+            
+            $productActionObject = $objectManager->create('Magento\Catalog\Model\Product\Action');
+            $productActionObject->updateAttributes($productIds, array('rm_interest_options' => ""), 0);
+            $productActionObject->updateAttributes($productIds,array('rm_pagseguro_last_update' => 0), 0);
+        }
+    }
 }


### PR DESCRIPTION
Foi inserida uma conferência para evitar que a função de atualização de atributos seja chamada com um arranjo de ID's vazio, corrigindo o problema relatado.

Consegui reproduzir o problema em qualquer situação que resultava em uma limpeza dos caches (cache:clean), como por exemplo a instalação do Magento.

Acabei criando uma função privada para referenciar um bloco de código que se repetia, para facilitar a conferência e a manutenção. Evitei ir muito além do escopo da correção, mas removi a adição de campos ao select (->addAttributesToSelect(*)), pois não notei a utilização de qualquer atributo do produto no restante do código.