### PR TITLE
Adição de trecho de URL a ser ignorada no metodo validate

### DIFF
--- a/Model/Method/Cc.php
+++ b/Model/Method/Cc.php
@@ -341,8 +341,12 @@ class Cc extends \Magento\Payment\Model\Method\Cc
      */
     public function validate()
     {
-        if(stristr($this->request->getUriString(),"/set-payment-information"))
+        if( stristr($this->request->getUriString(),"/set-payment-information") || 
+            stristr($this->request->getUriString(),"/selected-payment-method")
+        ) {
             return $this;
+        }
+
         $info = $this->getInfoInstance();
 
         $senderHash = $info->getAdditionalInformation('sender_hash');


### PR DESCRIPTION
A classe já desconsiderava o trecho da URL de atualização da escolha do método de pagamento no checkout do Magento, visando barrar a execução do método validate nas ações na API terminadas em /set-payment-information. Agora foi adicionado trecho que visa barrar as ações na API terminadas em /selected-payment-method.

Não pude testar devidamente esta ação, uma vez que o checkout do Magento não utiliza este terminal da API durante o checkout. Utilizei o Postman para realizar a requisição em meu checkout local, reproduzindo os cabeçalhos.