### PR TITLE
Configuração de parcelas sem juros na página do produto

### DIFF
--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -131,6 +131,12 @@
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <comment>Beta: this feature is in tests. You must enable your cronjob and the corresponding PagSeguro cache in the cache section to work properly. Currently available only for simple, digital and virtual products.</comment>
                 </field>
+                <field id="show_installments_product_page_interest_free_only" translate="label" type="select" sortOrder="13" showInDefault="1" showInWebsite="1" showInStore="0">
+                    <label>Only display interest free installment options</label>
+                    <depends><field id="show_installments_product_page">1</field></depends>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <comment>If the configured value is Yes, only the maximum number of parcels without interest will be shown in the product page and, if there isn't more then 1 installment without interest, no message will be shown at all.</comment>
+                </field>
             </group>
              <!--Boleto / Bank billet-->
             <group id="rm_pagseguro_boleto" translate="label" sortOrder="21" showInDefault="1" showInWebsite="1" showInStore="1">

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -15,6 +15,8 @@
                 <info_brl>1</info_brl>
                 <show_total>0</show_total>
                 <force_installments_selection>0</force_installments_selection>
+                <show_installments_product_page>0</show_installments_product_page>
+                <show_installments_product_page_interest_free_only>0</show_installments_product_page_interest_free_only>
             </rm_pagseguro_cc>
             <rm_pagseguro>
                 <title>PagSeguro UOL</title>

--- a/i18n/pt_BR.csv
+++ b/i18n/pt_BR.csv
@@ -258,3 +258,5 @@
 "YYYY","AAAA"
 "Order %1 not found on system. Unable to process return. A new attempt may happen in a few minutes.","Pedido %1 não encontrado. Impossível processar o retorno. Uma nova tentativa deve ocorrer em alguns minutos."
 "Failed to process PagSeguro response. A new attempt may happen in a few minutes.","Falha ao processar retorno do PagSeguro. Uma nova tentativa deve ocorrer em alguns minutos."
+"Only display interest free installment options","Exibir apenas parcelas sem juros"
+"If the configured value is Yes, only the maximum number of parcels without interest will be shown in the product page and, if there isn't more then 1 installment without interest, no message will be shown at all.","Caso o valor configurado seja Sim, o número máximo de parcelas mostrado na mensagem considerará somente as que não possuem juros. Caso não haja parcelamento sem juros disponível (somente à vista), a mensagem não será mostrada."


### PR DESCRIPTION
Foi inserida configuração na administração para determinar se as parcelas mostradas na página do produto devem considerar somente parcelas sem juros. 

Caso esta opção seja preenchida com o valor 'Sim', a mensagem principal irá considerar somente parcelas sem juros. Quando não houver possibilidade de parcelamento sem juros e esta opção estiver marcada, a mensagem não é mostrada.