### PR TITLE
Adição de evento de notificação recebida

### DIFF
--- a/Model/Notifications.php
+++ b/Model/Notifications.php
@@ -322,6 +322,11 @@ class Notifications extends \Magento\Payment\Model\Method\AbstractMethod
                 . $return);
         }
 
+        $this->_eventManager->dispatch('rm_pagseguro_status_notification_received', [
+            'responseText' => $return,
+            'responseXml'  => $xml,
+        ]);
+
         curl_close($ch);
         return $xml;
     }


### PR DESCRIPTION
Quando uma notificação é recebida no Magento, após o retorno da consulta à PagSeguro, um evento é disparado com o XML de retorno da PagSeguro. O evento disparado fornece a resposta da PagSeguro no formato de String (responseText) e no formato de Objeto XML - SimpleXMLElement (responseXml).