### PR TITLE
Status 'Pagamento Pendente' para pedidos via 'Pagar na PagSeguro'

### DIFF
--- a/Model/Method/Redirect.php
+++ b/Model/Method/Redirect.php
@@ -155,7 +155,7 @@ class Redirect extends \RicardoMartins\PagSeguro\Model\Method\AbstractMethodExte
                 }
                 $this->cookieHelper->set('redirectURL', $redirectUrl, 3600);
                 $order->setStatus($this->getConfigData('order_status'));
-                $order->setState(Order::STATE_NEW);
+                $order->setState(Order::STATE_PENDING_PAYMENT);
             }
 
         } catch (\Exception $e) {

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -223,7 +223,7 @@
                 </field>
                 <field id="order_status" translate="label" type="select" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="0">
                     <label>New Order Status</label>
-                    <source_model>Magento\Sales\Model\Config\Source\Order\Status\NewStatus</source_model>
+                    <source_model>Magento\Sales\Model\Config\Source\Order\Status</source_model>
                 </field>
                 <field id="accepted_groups" translate="label" type="multiselect" sortOrder="50" showInDefault="1" showInWebsite="1" showInStore="0">
                     <label>Pagamentos aceitos</label>


### PR DESCRIPTION
Alteração na configuração do status do método de pagamento e no state padrão atribuído na criação do pedido no Magento, para seguir fluxo similar ao pagamento via Boleto Bancário.