### PR TITLE
Problema no Carrinho -  Página em Branco

### DIFF
--- a/etc/frontend/di.xml
+++ b/etc/frontend/di.xml
@@ -10,7 +10,7 @@
     <type name="Magento\Checkout\Model\CompositeConfigProvider">
         <arguments>
             <argument name="configProviders" xsi:type="array">
-                <item name="rm_pagseguro_cc_config_provider" xsi:type="object">RicardoMartins\PagSeguro\Model\ConfigProvider</item>\
+                <item name="rm_pagseguro_cc_config_provider" xsi:type="object">RicardoMartins\PagSeguro\Model\ConfigProvider</item>
                 <item name="rm_pagseguro_redirect_config_provider" xsi:type="object">RicardoMartins\PagSeguro\Model\AdditionalConfigProvider</item>
             </argument>
         </arguments>


### PR DESCRIPTION
Postagens relacionadas:

https://github.com/r-martins/PagSeguro-Magento-Transparente-M2/issues/86

https://pagsegurotransparente.zendesk.com/hc/pt-br/articles/360029342892-Checkout-n%C3%A3o-carrega-ap%C3%B3s-instala%C3%A7%C3%A3o-ou-atualiza%C3%A7%C3%A3o-do-m%C3%B3dulo-Magento-2-?mobile_site=true

Solucionado!