### PR TITLE
Link de atualização manual no admin não aparece

### DIFF
--- a/Controller/Adminhtml/Update/Index.php
+++ b/Controller/Adminhtml/Update/Index.php
@@ -8,7 +8,7 @@ use Magento\Framework\App\Action\HttpGetActionInterface;
 
 class Index extends Action implements HttpGetActionInterface
 {
-    public const ADMIN_RESOURCE = 'RicardoMartins::pagseguro_manual_update';
+    public const ADMIN_RESOURCE = 'RicardoMartins_PagSeguro::pagseguro_manual_update';
 
     /**
      * @var \Magento\Framework\HTTP\Client\Curl


### PR DESCRIPTION
Correção do índice de permissão no ACL do controlador e do bloco para mostrar o link de atualização manual na página do pedido no backend do Magento.