### PR TITLE
Fix: 'Undefined index: second_cc_owner_birthday_day'

### DIFF
--- a/Model/Method/Twocc.php
+++ b/Model/Method/Twocc.php
@@ -522,13 +522,13 @@ class Twocc extends \Magento\Payment\Model\Method\Cc
                     )
                 )
             );
-            $dobDay = $data['additional_data']['second_cc_owner_birthday_day'] ? trim(
+            $dobDay = isset($data['additional_data']['second_cc_owner_birthday_day']) ? trim(
                 $data['additional_data']['second_cc_owner_birthday_day']
             ) : '01';
-            $dobMonth = $data['additional_data']['second_cc_owner_birthday_month'] ? trim(
+            $dobMonth = isset($data['additional_data']['second_cc_owner_birthday_month']) ? trim(
                 $data['additional_data']['second_cc_owner_birthday_month']
             ) : '01';
-            $dobYear = $data['additional_data']['second_cc_owner_birthday_year'] ? trim(
+            $dobYear = isset($data['additional_data']['second_cc_owner_birthday_year']) ? trim(
                 $data['additional_data']['second_cc_owner_birthday_year']
             ) : '1970';
             $info->setAdditionalInformation(


### PR DESCRIPTION
Quando a data de nascimento do segundo cartão não está preenchida no módulo Single Step Checkout da Amasty, aparece a seguinte mensagem:
Notice: Undefined index: second_cc_owner_birthday_day in vendor/ricardomartins/pagseguro/Model/Method/Twocc.php on line 525