### PR TITLE
Correção de bug no Fireckout

### DIFF
--- a/etc/module.xml
+++ b/etc/module.xml
@@ -7,6 +7,7 @@
             <module name="Magento_Checkout"/>
             <module name="Magento_Directory" />
             <module name="Magento_Config" />
+            <module name="Swissup_Firecheckout" />
         </sequence>
     </module>
 </config>

--- a/view/frontend/requirejs-config.js
+++ b/view/frontend/requirejs-config.js
@@ -6,11 +6,10 @@ var config = {
     },
     config: {
         // Disables the firecheckout mixin on payment service model of Magento Checkout.
-        // Its avoids bugs when coupon is applied / cancenled on checkout page.
+        // This avoids bugs when coupon is applied / cancenled on checkout page.
         mixins: {
             'Magento_Checkout/js/model/payment-service': {
-                'Swissup_Firecheckout/js/mixin/model/payment-service-mixin': false,
-                'RicardoMartins_PagSeguro/js/mixin/model/firecheckout-fix': true
+                'Swissup_Firecheckout/js/mixin/model/payment-service-mixin': false
             }
         }
     }

--- a/view/frontend/requirejs-config.js
+++ b/view/frontend/requirejs-config.js
@@ -3,5 +3,15 @@ var config = {
         '*': {
             'Magento_Checkout/js/model/place-order':'RicardoMartins_PagSeguro/js/model/place-order'
         }
+    },
+    config: {
+        // Disables the firecheckout mixin on payment service model of Magento Checkout.
+        // Its avoids bugs when coupon is applied / cancenled on checkout page.
+        mixins: {
+            'Magento_Checkout/js/model/payment-service': {
+                'Swissup_Firecheckout/js/mixin/model/payment-service-mixin': false,
+                'RicardoMartins_PagSeguro/js/mixin/model/firecheckout-fix': true
+            }
+        }
     }
 };

--- a/view/frontend/web/js/mixin/model/firecheckout-fix.js
+++ b/view/frontend/web/js/mixin/model/firecheckout-fix.js
@@ -1,9 +1,0 @@
-define([    
-], function () {
-    'use strict';
-
-    // returns the original function of the magento checkout
-    return function(target) {
-        return target;
-    };
-});

--- a/view/frontend/web/js/mixin/model/firecheckout-fix.js
+++ b/view/frontend/web/js/mixin/model/firecheckout-fix.js
@@ -1,0 +1,9 @@
+define([    
+], function () {
+    'use strict';
+
+    // returns the original function of the magento checkout
+    return function(target) {
+        return target;
+    };
+});


### PR DESCRIPTION
O módulo Swissup_Firecheckout possui um mixin no checkout do Magento que tenta repreencher os campos do formulário de pagamento que esteja ativo quando os formulários de pagamento são recarregados - por exemplo, na aplicação e no cancelamento de uso de cupons de desconto.

Este comportamento acarreta em diversos problemas / erros, pois diversos observers do formulário de pagamento são ignorados.

A solução proposta foi desabilitar o mixin do Firecheckout.
