### PR TITLE
Quantidade decimal de produtos enviados à PagSeguro

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -700,6 +700,16 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
                 $return['itemDescription'.$x] = substr($items[$y]->getName(), 0, 100);
                 $return['itemAmount'.$x] = number_format($itemPrice, 2, '.', '');
                 $return['itemQuantity'.$x] = (int) $qtyOrdered;
+
+                if ($items[$y]->getIsQtyDecimal()) {
+                    $qtyDescription = ' (' . $items[$y]->getQtyOrdered() . ' un.)';
+                    
+                    $return['itemQuantity'.$x] = 1;
+                    $return['itemAmount'.$x] = number_format($items[$y]->getRowTotalInclTax() * $percent, 2, '.', '');
+                    $return['itemDescription'.$x] =
+                        substr($items[$y]->getName(), 0, 100 - strlen($qtyDescription)) .
+                        $qtyDescription;
+                }
             }
         }
         return $return;


### PR DESCRIPTION
Quando um produto possui um valor decimal na quantidade comprada, alteramos os dados enviados à PagSeguro passando o número decimal para a descrição do produto e alterando a quantidade comprada para um (1), evitando problemas de compatibilidade com a PagSeguro.