### PR TITLE
Compatibilização do módulo com captcha no checkout do Magento

### DIFF
--- a/Model/Payment.php
+++ b/Model/Payment.php
@@ -17,7 +17,7 @@ class Payment extends \Magento\Payment\Model\Method\Cc
      */
     protected $_formBlockType = \RicardoMartins\PagSeguro\Block\Form\Cc::class;
 
-    const CODE = 'rm_pagseguro_cc';
+    const CODE = 'rm_pagseguro';
 
     protected $_code = self::CODE;
     protected $_isGateway                   = true;

--- a/etc/frontend/di.xml
+++ b/etc/frontend/di.xml
@@ -3,7 +3,7 @@
     <virtualType name="RicardoMartins\PagSeguro\Model\ConfigProvider" type="Magento\Payment\Model\CcGenericConfigProvider">
         <arguments>
             <argument name="methodCodes" xsi:type="array">
-                <item name="rm_pagseguro_cc" xsi:type="const">RicardoMartins\PagSeguro\Model\Payment::CODE</item>
+                <item name="rm_pagseguro_cc" xsi:type="const">RicardoMartins\PagSeguro\Model\Method\Cc::CODE</item>
                 <item name="rm_pagseguro_twocc" xsi:type="const">RicardoMartins\PagSeguro\Model\Method\Twocc::CODE</item>
             </argument>
         </arguments>

--- a/view/frontend/requirejs-config.js
+++ b/view/frontend/requirejs-config.js
@@ -1,9 +1,11 @@
 var config = {
+    /*
     map: {
         '*': {
             'Magento_Checkout/js/model/place-order':'RicardoMartins_PagSeguro/js/model/place-order'
         }
     },
+    */
     config: {
         // Disables the firecheckout mixin on payment service model of Magento Checkout.
         // This avoids bugs when coupon is applied / cancelled on checkout page.

--- a/view/frontend/web/js/pagseguro.js
+++ b/view/frontend/web/js/pagseguro.js
@@ -344,7 +344,7 @@ RMPagSeguro.prototype.updateOneCreditCardToken = function(successCallback = null
                 console.log(psresponse);
                 self.creditCardToken = psresponse.card.token;
                 self.updatePaymentHashes();
-                self.getInstallments(self.grandTotal, self.installmentsQty);
+                //self.getInstallments(self.grandTotal, self.installmentsQty);
                 jQuery('#card-msg').html('');
 
                 if (successCallback) {

--- a/view/frontend/web/template/payment/rm_pagseguro_cc.html
+++ b/view/frontend/web/template/payment/rm_pagseguro_cc.html
@@ -8,7 +8,9 @@
         <div data-bind="html: getPagSeguroCcImagesHtml()" id="rm_pagseguro_ccflags"></div>
     </div>
     <div class="payment-method-content" id="pagseguro_cc_method">
-        <div id="checkout-messages" class="messages"></div>
+        <!-- ko foreach: getRegion('messages') -->
+        <!-- ko template: getTemplate() --><!-- /ko -->
+        <!--/ko-->
         <div class="payment-method-billing-address">
             <!-- ko foreach: $parent.getRegion(getBillingAddressFormName()) -->
             <!-- ko template: getTemplate() --><!-- /ko -->

--- a/view/frontend/web/template/payment/rm_pagseguro_twocc.html
+++ b/view/frontend/web/template/payment/rm_pagseguro_twocc.html
@@ -8,7 +8,9 @@
         <div data-bind="html: getPagSeguroCcImagesHtml()" id="rm_pagseguro_twoccflags"></div>
     </div>
     <div class="payment-method-content" id="pagseguro_twocc_method">
-        <div id="checkout-messages" class="messages"></div>
+        <!-- ko foreach: getRegion('messages') -->
+        <!-- ko template: getTemplate() --><!-- /ko -->
+        <!--/ko-->
         <div class="payment-method-billing-address">
             <!-- ko foreach: $parent.getRegion(getBillingAddressFormName()) -->
             <!-- ko template: getTemplate() --><!-- /ko -->


### PR DESCRIPTION
Foi removida a reescrita da função de 'place order' do Magento, uma vez que esta funcionalidade foi atualizada para utilizar o captcha interno da plataforma e / ou o recaptcha do Google.

Além disso, as mensagens no formulário de pagamento passaram a seguir o padrão da plataforma e houve uma alteração (remoção de referência para classe legada) no código PHP para que isto fosse possível.