### PR TITLE
Função de recálculo automático de parcelas

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -517,7 +517,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
             // checks all transaction errors, except the refund transactions
             // that could not succeed because of the transaction status
             // error code 14007: invalid transaction status to refund
-            if ($type !== "transactions/refunds" && $xml->error->code != '14007' && $xml->error->code != '53041') {
+            if ($type !== "transactions/refunds" && $xml->error->code != '14007') {
                 $errArray = [];
                 $xmlError = json_decode(json_encode($xml), true);
                 $xmlError = $xmlError['error'];

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -33,8 +33,8 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     const XML_PATH_PAYMENT_PAGSEGURO_SANDBOX_WS_URL_APP = 'payment/rm_pagseguro/sandbox_ws_url_app';
     const XML_PATH_PAYMENT_PAGSEGURO_ENABLE_UPDATER     = 'payment/rm_pagseguro/enable_updater';
     const XML_PATH_PAYMENT_PAGSEGURO_SANDBOX_JS_URL     = 'https://stc.sandbox.pagseguro.uol.com.br/pagseguro/api/v2/checkout/pagseguro.directpayment.js';
-    const XML_PATH_PAYMENT_PAGSEGURO_CHECKOUT_URL       = 'https://pagseguro.uol.com.br/checkout/v2/installments.json';
-    const XML_PATH_PAYMENT_PAGSEGURO_SANDBOX_CHECKOUT_URL = 'https://sandbox.pagseguro.uol.com.br/checkout/v2/installments.json';
+    const PAGSEGURO_CHECKOUT_URL                        = 'https://pagseguro.uol.com.br/checkout/v2/installments.json';
+    const PAGSEGURO_SANDBOX_CHECKOUT_URL                = 'https://sandbox.pagseguro.uol.com.br/checkout/v2/installments.json';
     const XML_PATH_PAYMENT_PAGSEGURO_CC_ACTIVE          = 'payment/rm_pagseguro_cc/active';
     const XML_PATH_PAYMENT_PAGSEGURO_TWOCC_ACTIVE       = 'payment/rm_pagseguro_twocc/active';
     const XML_PATH_PAYMENT_PAGSEGURO_CC_FLAG            = 'payment/rm_pagseguro_cc/flag';
@@ -1368,10 +1368,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     {
         $installmentsQty = $params['installmentQuantity'];
         
-        $url = $this->isSandbox()
-            ? self::XML_PATH_PAYMENT_PAGSEGURO_SANDBOX_CHECKOUT_URL
-            : self::XML_PATH_PAYMENT_PAGSEGURO_CHECKOUT_URL;
-            
+        $url = $this->isSandbox() ? self::PAGSEGURO_SANDBOX_CHECKOUT_URL : self::PAGSEGURO_CHECKOUT_URL;
         $url .= '?' . http_build_query([
             'sessionId'       => $this->getSessionId(),
             'amount'          => number_format($amount, 2, '.', ''),

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -578,8 +578,6 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
             );
         }
 
-        $this->writeLog('retorna o XML');
-
         return $xml;
     }
 

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -1384,7 +1384,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         $response = json_decode($this->httpClient->getBody());
 
         if (!isset($response->installments->{$creditCardBrand}[$installmentsQty-1]->installmentAmount)) {
-            return null;
+            throw new LocalizedException(__('installment value invalid value: %1', $params['installmentValue']));
         }
         
         $installmentsValue = (float) $response->installments->{$creditCardBrand}[$installmentsQty-1]->installmentAmount;

--- a/Model/Exception/WrongInstallmentsException.php
+++ b/Model/Exception/WrongInstallmentsException.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace RicardoMartins\PagSeguro\Model\Exception;
+
+use Magento\Framework\Exception\LocalizedException;
+
+/**
+ * Class that represents a wrong installments exception. That exception
+ * occurs when the value of the parcels sent to PagSeguro are inconsistent
+ * with the order total and the interest value of the transaction
+ */
+class WrongInstallmentsException extends LocalizedException
+{
+}

--- a/Model/Method/Cc.php
+++ b/Model/Method/Cc.php
@@ -190,14 +190,7 @@ class Cc extends \Magento\Payment\Model\Method\Cc
         try {
             $returnXml = $this->pagSeguroHelper->callApi($params, $payment);
         } catch (WrongInstallmentsException $e) {
-            $returnXml = $this->pagSeguroHelper->recalcInstallmentsAndResendOrder(
-                $params,
-                $payment,
-                $payment->getOrder()->getGrandTotal(),
-                $payment->getCcType()
-            );
-
-            $payment->setAdditionalInformation('recalculated_installments', true);
+            $returnXml = $this->pagSeguroHelper->recalcInstallmentsAndResendOrder($params, $payment);
         }
 
         return $returnXml;

--- a/Model/Method/Twocc.php
+++ b/Model/Method/Twocc.php
@@ -263,14 +263,7 @@ class Twocc extends \Magento\Payment\Model\Method\Cc
         try {
             $returnXml = $this->pagSeguroHelper->callApi($params, $payment);
         } catch (WrongInstallmentsException $e) {
-            $returnXml = $this->pagSeguroHelper->recalcInstallmentsAndResendOrder(
-                $params,
-                $payment,
-                floatval($payment->getAdditionalInformation('credit_card_amount' . $cardIndex)),
-                $payment->getAdditionalInformation('credit_card_type' . $cardIndex)
-            );
-
-            $payment->setAdditionalInformation('recalculated_installments' . $cardIndex, true);
+            $returnXml = $this->pagSeguroHelper->recalcInstallmentsAndResendOrder($params, $payment, $cardIndex);
         }
 
         return $returnXml;


### PR DESCRIPTION
Quando um erro de valor inválido de parcelas for retornado pelo servidor da PagSeguro (código 53041), o módulo tentará recalcular as parcelas automaticamente e realizar outra vez o envio da transação.

Quando isto acontece, um flag é registrado nas informações adicionais do objeto que representa o pagamento do pedido:

- recalculated_installments = true (pedidos de 1 cartão);
- recalculated_installments_first = true (primeiro cartão de pedidos com 2 cartões);
- recalculated_installments_second = true (segundo cartão de pedidos com 2 cartões).